### PR TITLE
Update monitors.json 2016/12/08 22:51:10.

### DIFF
--- a/mackerel/monitors.json
+++ b/mackerel/monitors.json
@@ -1,16 +1,6 @@
 {
     "monitors": [
         {
-            "id": "2q6gEBtAwdQ",
-            "name": "ディスク容量",
-            "type": "host",
-            "metric": "filesystem.vda3.used",
-            "operator": ">",
-            "warning": 6e+10,
-            "critical": 9e+10,
-            "duration": 1
-        },
-        {
             "id": "2jyNUkg1Pzs",
             "name": "connectivity",
             "type": "connectivity",


### PR DESCRIPTION
job: 
Summary: 0 modify, 1 append, 0 remove

+{
+  "id": "2q6gEBtAwdQ",
+  "name": "ディスク容量",
+  "type": "host",
+  "metric": "filesystem.vda3.used",
+  "operator": ">",
+  "warning": 6e+10,
+  "critical": 9e+10,
+  "duration": 1
+},